### PR TITLE
Fix occasional playback loop

### DIFF
--- a/Sonos/module.php
+++ b/Sonos/module.php
@@ -475,6 +475,7 @@ class Sonos extends IPSModule
           }
 
           $sonos->SetAVTransportURI($uri);
+	  $sonos->SetPlayMode(0);	
           $sonos->Play();
           IPS_Sleep(500);
           $fileTransportInfo = $sonos->GetTransportInfo();


### PR DESCRIPTION
Sometimes "SNS_PlayFiles" loops the sound file indefinitely (does not return) until "SNS_Stop" command issued or stop pressed in Sonos Controller. This change does fix it for me.