### PR TITLE
Undefined variable: group

### DIFF
--- a/Sonos/_updateGrouping.php
+++ b/Sonos/_updateGrouping.php
@@ -25,6 +25,7 @@ IPS_SetScriptTimer($_IPS["SELF"], $frequency);
 $sonos = new SonosAccess($ipAddress);
 
 $grouping = new SimpleXMLElement($sonos->GetZoneGroupState());
+$group = 0;
 
 foreach($allSonosInstances as $key=>$SonosID) {
     $rincon = IPS_GetProperty($SonosID ,"RINCON");


### PR DESCRIPTION
If you have grouped Sonos players, there will be an error in line 47, because $group is not defined.