### PR TITLE
Solved "Coordinator for Instance not found"

### DIFF
--- a/Sonos/_updateGrouping.php
+++ b/Sonos/_updateGrouping.php
@@ -27,10 +27,14 @@ $sonos = new SonosAccess($ipAddress);
 $grouping = new SimpleXMLElement($sonos->GetZoneGroupState());
 $group = 0;
 
+// Some of my speakers moved ZoneGroup to ZoneGroups->ZoneGroup what leads to an error - this should solve it
+$zoneGroups = $grouping->ZoneGroup;
+if(count($zoneGroups) == 0) $zoneGroups = $grouping->ZoneGroups->ZoneGroup;
+
 foreach($allSonosInstances as $key=>$SonosID) {
     $rincon = IPS_GetProperty($SonosID ,"RINCON");
-	$coordinatorInSonos = false;
-    foreach ($grouping->ZoneGroup as $zoneGroup){
+    $coordinatorInSonos = false;
+    foreach ($zoneGroups as $zoneGroup){
     	if ( $zoneGroup->attributes()['Coordinator'] == $rincon ){  
 		      $coordinatorInSonos = true; 
         }


### PR DESCRIPTION
Some of my Speakers generates "Coordinator Instance for Group of Sonos Instance x not found" error.
Seem that the XML structure changed (maybe an Firmware Update by Sonos?).

Implemented an simple workaround.