### PR TITLE
Fix: JSON may not decoded as array

### DIFF
--- a/Sonos/module.php
+++ b/Sonos/module.php
@@ -515,7 +515,7 @@ class Sonos extends IPSModule
     public function PlayFiles(string $files, string $volumeChange)
     {
         $ip = $this->getIP();
-		$filesArray = json_decode($files);
+		$filesArray = json_decode($files, true);
 
         include_once(__DIR__ . "/sonosAccess.php");
         $sonos = new SonosAccess($ip);
@@ -609,7 +609,7 @@ class Sonos extends IPSModule
     public function PlayFilesGrouping(string $instances, string $files, string $volumeChange)
     {
         $ip = $this->getIP();
-		$instancesArray = json_decode($instances);
+		$instancesArray = json_decode($instances, true);
 		
         include_once(__DIR__ . "/sonosAccess.php");
         $sonos         = new SonosAccess($ip);


### PR DESCRIPTION
Latest update kills SNS_PlayFilesGrouping for me because json_decode decodes $instances Array to stdClass Objects and not associative arrays. But Line 649 needs associative array and not StdClass Object.

Added true parameter to json_decode to force associative array